### PR TITLE
make uniform cdr noise a toggle, default off

### DIFF
--- a/src/vivarium_experiment_dementia/components/cdr.py
+++ b/src/vivarium_experiment_dementia/components/cdr.py
@@ -5,7 +5,8 @@ class DementiaProgression:
 
     configuration_defaults = {
         'dementia_model': {
-            'cdr_rate': 0.406667  # annual increase. corresponds to cdr_sb of 2.44
+            'cdr_rate': 0.406667,  # annual increase. corresponds to cdr_sb of 2.44
+            'uniform_cdr_noise': False
         }
     }
 
@@ -62,7 +63,8 @@ class DementiaProgression:
         dementia_cdr = dementia_cdr.replace({'mild': 1.0, 'moderate': 2.0, 'severe': 3.0})
 
         # add uniform noise
-        dementia_cdr += self.randomness_cdr_noise.get_draw(dementia_index)
+        if self.config['uniform_cdr_noise']:
+            dementia_cdr += self.randomness_cdr_noise.get_draw(dementia_index)
 
         # put back in
         pop.loc[dementia_index, 'cdr'] = dementia_cdr

--- a/src/vivarium_experiment_dementia/model_specifications/vivarium_experiment_dementia.yaml
+++ b/src/vivarium_experiment_dementia/model_specifications/vivarium_experiment_dementia.yaml
@@ -47,6 +47,7 @@ configuration:
 
     dementia_model:
         'cdr_rate': 0.406667  # annual increase. corresponds to cdr_sb of 2.44
+        'uniform_cdr_noise': False
 
     metrics:
         disability:


### PR DESCRIPTION
This is a request from Yash, he says the uniform noise is messing up results. I made it a switch because it was easy and b/c I don't want to have to PR again to revert it if that happens down the line.


